### PR TITLE
feat: add registry contract draft

### DIFF
--- a/contracts/RevocationRegistry.sol
+++ b/contracts/RevocationRegistry.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.8;
+
+contract RevocationRegistry {
+
+    mapping(bytes32 => mapping(address => uint)) public revocations;
+
+    function revoke(bytes32 digest) public returns (bool) {
+        revocations[digest][msg.sender] = block.number;
+        emit Revoked(msg.sender, digest);
+        return true;
+    }
+
+    function revoked(address party, bytes32 digest) public view returns (bool) {
+        return revocations[digest][party] > 0;
+    }
+
+    event Revoked(address revoker, bytes32 digest);
+}


### PR DESCRIPTION
This is a simple contract for revocation of arbitrary data.

The inputs for a revocation are the `msg.sender` and a `bytes32` digest of the data.
A read-only method to check if a hash has been revoked by an address is provided.

Not sure if the event `Revoked` is needed.
Not sure if the initial contract should contain a `revokeFor(bytes32 digest, v,r,s)` method.