### PR TITLE
return revocation block and add testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const blockNumber = revoked.toNumber() // block number when it was revoked by `i
 
 ## Deployments
 
-Rinkeby: 0xf9494aE9AbA7B54856Ee56F9AdFC635988Df1A36
+Rinkeby: 0x97fd27892cdcD035dAe1fe71235c636044B59348
 
 ## Contributions
 
@@ -46,4 +46,3 @@ And, of course, please make sure to update tests as appropriate.
 ## License
 
 https://choosealicense.com/licenses/apache-2.0/
-

--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # revocation-registry
-ethereum revocation registry contract
+
+Contract backing the `EthrStatusRegistry2019` verifiable credential status method
+
+## Usage
+
+This is a very simple contract that can be used to timestamp data on-chain.
+The first use of this is for marking verifiable credentials as revoked, but it can be used for committing any
+32 byte digest of data to chain.
+
+**Anyone can revoke anything**, it is up to potential verifiers to check if the parties they care about have revoked
+the credentials that they are verifying.
+
+To mark a credential to the registry:
+
+```javascript
+const issuer = "0xYourEthereumAddress"
+const credential = "some verifiable credential (JWT issued by `issuer`) but it can be any data since it gets hashed."
+const digest = sha3(credential).toString('hex')
+
+const tx = revocationRegistry.revoke(digest, { from: issuer })
+
+```
+
+Then, to check if it has been marked:
+```javascript
+const issuer = "0xSomeEthereumAddress"
+const credential = "some verifiable credential (JWT issued by `issuer`) but it can be any data since it gets hashed."
+const digest = sha3(credential).toString('hex')
+
+const revoked = revocationRegistry.revoked.call(issuer, digest)
+
+const blockNumber = revoked.toNumber() // block number when it was revoked by `issuer`, or 0 if it was not
+```
+
+## Deployments
+
+Rinkeby: 0x30EE91c33c9539Cdc1Bde1F3927C49E7D925420f
+
+## Contributions
+
+Pull requests are welcome.
+Please open an issue first to discuss what you would like to change.
+And, of course, please make sure to update tests as appropriate.
+
+## License
+
+https://choosealicense.com/licenses/apache-2.0/
+

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const blockNumber = revoked.toNumber() // block number when it was revoked by `i
 
 ## Deployments
 
-Rinkeby: 0x30EE91c33c9539Cdc1Bde1F3927C49E7D925420f
+Rinkeby: 0xf9494aE9AbA7B54856Ee56F9AdFC635988Df1A36
 
 ## Contributions
 

--- a/contracts/RevocationRegistry.sol
+++ b/contracts/RevocationRegistry.sol
@@ -4,19 +4,19 @@ contract RevocationRegistry {
 
     mapping(bytes32 => mapping(address => uint)) private revocations;
 
-    function revoke(bytes32 digest) public returns (bool) {
-        if (revocations[digest][msg.sender] == 0) {
-            revocations[digest][msg.sender] = block.number;
-            emit Revoked(msg.sender, digest);
-            return true;
-        } else {
-            return false;
-        }
+    modifier onlyOnce(bytes32 digest) {
+        require (revocations[digest][msg.sender] == 0);
+        _;
     }
 
-    function revoked(address party, bytes32 digest) public view returns (uint) {
-        return revocations[digest][party];
+    function revoke(bytes32 digest) public onlyOnce(digest) {
+        revocations[digest][msg.sender] = block.number;
+        emit Revoked(msg.sender, digest);
     }
 
-    event Revoked(address revoker, bytes32 digest);
+    function revoked(address issuer, bytes32 digest) public view returns (uint) {
+        return revocations[digest][issuer];
+    }
+
+    event Revoked(address issuer, bytes32 digest);
 }

--- a/contracts/RevocationRegistry.sol
+++ b/contracts/RevocationRegistry.sol
@@ -5,9 +5,13 @@ contract RevocationRegistry {
     mapping(bytes32 => mapping(address => uint)) private revocations;
 
     function revoke(bytes32 digest) public returns (bool) {
-        revocations[digest][msg.sender] = block.number;
-        emit Revoked(msg.sender, digest);
-        return true;
+        if (revocations[digest][msg.sender] == 0) {
+            revocations[digest][msg.sender] = block.number;
+            emit Revoked(msg.sender, digest);
+            return true;
+        } else {
+            return false;
+        }
     }
 
     function revoked(address party, bytes32 digest) public view returns (uint) {

--- a/contracts/RevocationRegistry.sol
+++ b/contracts/RevocationRegistry.sol
@@ -4,12 +4,8 @@ contract RevocationRegistry {
 
     mapping(bytes32 => mapping(address => uint)) private revocations;
 
-    modifier onlyOnce(bytes32 digest) {
+    function revoke(bytes32 digest) public {
         require (revocations[digest][msg.sender] == 0);
-        _;
-    }
-
-    function revoke(bytes32 digest) public onlyOnce(digest) {
         revocations[digest][msg.sender] = block.number;
         emit Revoked(msg.sender, digest);
     }

--- a/contracts/RevocationRegistry.sol
+++ b/contracts/RevocationRegistry.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.8;
 
 contract RevocationRegistry {
 
-    mapping(bytes32 => mapping(address => uint)) public revocations;
+    mapping(bytes32 => mapping(address => uint)) private revocations;
 
     function revoke(bytes32 digest) public returns (bool) {
         revocations[digest][msg.sender] = block.number;
@@ -10,8 +10,8 @@ contract RevocationRegistry {
         return true;
     }
 
-    function revoked(address party, bytes32 digest) public view returns (bool) {
-        return revocations[digest][party] > 0;
+    function revoked(address party, bytes32 digest) public view returns (uint) {
+        return revocations[digest][party];
     }
 
     event Revoked(address revoker, bytes32 digest);

--- a/test/basic.js
+++ b/test/basic.js
@@ -53,21 +53,18 @@ contract('RevocationRegistry', function(accounts) {
       let event = tx.logs[0]
 
       assert.equal(event.event, "Revoked");
-      assert.equal(event.args.revoker, accounts[0]);
+      assert.equal(event.args.issuer, accounts[0]);
       assert.equal(event.args.digest, digest);
     });
 
     it("Should not revoke same digest twice", async () => {
       const digest = "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
-      let tx1 = await registryInstance.revoke( digest, { from: accounts[0] })
-      let result1 = await registryInstance.revoked.call( accounts[0], digest )
-
-      let tx2 = await registryInstance.revoke( digest, { from: accounts[0] })
-      let result2 = await registryInstance.revoked.call( accounts[0], digest )
-
-      assert.isEmpty(tx2.logs)
-
-      assert.equal(result1.toNumber(), result2.toNumber())
+      await registryInstance.revoke( digest, { from: accounts[0] })
+      try {
+        await registryInstance.revoke( digest, { from: accounts[0] })
+      } catch (e) {
+        assert.equal( e.message, 'Returned error: VM Exception while processing transaction: revert' );
+      }
     });
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,11 +10,9 @@ contract('RevocationRegistry', function(accounts) {
 
   describe("revoked", () => {
     it("Should throw an invalid value when digest input longer than 32 bytes", async () => {
+      const digest = "0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900"
       try {
-        await registryInstance.revoked.call(
-                        accounts[0],
-                        "0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900"
-                      )
+        await registryInstance.revoked.call( accounts[0], digest )
       } catch (e) {
         assert.equal( e.message,
                       'invalid bytes32 value (arg="digest", coderType="bytes32", value="0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900")'
@@ -24,10 +22,7 @@ contract('RevocationRegistry', function(accounts) {
 
     it("Should throw an invalid value when digest is not a byte array", async () => {
       try {
-        await registryInstance.revoked.call(
-                        accounts[0],
-                        "some non hex string"
-                      )
+        await registryInstance.revoked.call( accounts[0], "some non hex string" )
       } catch (e) {
         assert.equal( e.message,
                       'invalid bytes32 value (arg="digest", coderType="bytes32", value="some non hex string")'
@@ -36,30 +31,43 @@ contract('RevocationRegistry', function(accounts) {
     });
 
     it("Should return 0 for non revoked digest", async () => {
-      let result = await registryInstance.revoked.call( accounts[0], "0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899" )
+      const digest = "0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+      let result = await registryInstance.revoked.call( accounts[0], digest )
       assert.equal(result.toNumber(), 0)
     });
 
     it("Should return block number for revoked digest", async () => {
-      let tx = await registryInstance.revoke("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+      const digest = "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      let tx = await registryInstance.revoke(digest,
         {
           from: accounts[0]
         })
 
-      let result = await registryInstance.revoked.call( accounts[0], "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" )
+      let result = await registryInstance.revoked.call( accounts[0], digest )
       assert.isAbove(result.toNumber(), 0)
     });
 
     it("Should create an event during revocation", async () => {
-      let tx = await registryInstance.revoke("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
-        {
-          from: accounts[0]
-        })
+      const digest = "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+      let tx = await registryInstance.revoke(digest, { from: accounts[0] })
       let event = tx.logs[0]
 
       assert.equal(event.event, "Revoked");
       assert.equal(event.args.revoker, accounts[0]);
-      assert.equal(event.args.digest, "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+      assert.equal(event.args.digest, digest);
+    });
+
+    it("Should not revoke same digest twice", async () => {
+      const digest = "0xabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcdabcd"
+      let tx1 = await registryInstance.revoke( digest, { from: accounts[0] })
+      let result1 = await registryInstance.revoked.call( accounts[0], digest )
+
+      let tx2 = await registryInstance.revoke( digest, { from: accounts[0] })
+      let result2 = await registryInstance.revoked.call( accounts[0], digest )
+
+      assert.isEmpty(tx2.logs)
+
+      assert.equal(result1.toNumber(), result2.toNumber())
     });
   })
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,66 @@
+const RevocationRegistry = artifacts.require("./RevocationRegistry.sol");
+
+contract('RevocationRegistry', function(accounts) {
+
+  let registryInstance;
+
+  beforeEach(async () => {
+    registryInstance = await RevocationRegistry.new()
+  })
+
+  describe("revoked", () => {
+    it("Should throw an invalid value when digest input longer than 32 bytes", async () => {
+      try {
+        await registryInstance.revoked.call(
+                        accounts[0],
+                        "0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900"
+                      )
+      } catch (e) {
+        assert.equal( e.message,
+                      'invalid bytes32 value (arg="digest", coderType="bytes32", value="0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900")'
+        );
+      }
+    });
+
+    it("Should throw an invalid value when digest is not a byte array", async () => {
+      try {
+        await registryInstance.revoked.call(
+                        accounts[0],
+                        "some non hex string"
+                      )
+      } catch (e) {
+        assert.equal( e.message,
+                      'invalid bytes32 value (arg="digest", coderType="bytes32", value="some non hex string")'
+        );
+      }
+    });
+
+    it("Should return 0 for non revoked digest", async () => {
+      let result = await registryInstance.revoked.call( accounts[0], "0xaabbccddeeff00112233445566778899aabbccddeeff00112233445566778899" )
+      assert.equal(result.toNumber(), 0)
+    });
+
+    it("Should return block number for revoked digest", async () => {
+      let tx = await registryInstance.revoke("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        {
+          from: accounts[0]
+        })
+
+      let result = await registryInstance.revoked.call( accounts[0], "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789" )
+      assert.isAbove(result.toNumber(), 0)
+    });
+
+    it("Should create an event during revocation", async () => {
+      let tx = await registryInstance.revoke("0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        {
+          from: accounts[0]
+        })
+      let event = tx.logs[0]
+
+      assert.equal(event.event, "Revoked");
+      assert.equal(event.args.revoker, accounts[0]);
+      assert.equal(event.args.digest, "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+    });
+  })
+
+});

--- a/test/basic.js
+++ b/test/basic.js
@@ -17,7 +17,10 @@ contract('RevocationRegistry', function(accounts) {
         assert.equal( e.message,
                       'invalid bytes32 value (arg="digest", coderType="bytes32", value="0xaabbccddeeff00112233445566778899aabbccddeeff0011223344556677889900")'
         );
+        return
       }
+
+      expect.fail("should have failed with an error")
     });
 
     it("Should throw an invalid value when digest is not a byte array", async () => {
@@ -27,7 +30,9 @@ contract('RevocationRegistry', function(accounts) {
         assert.equal( e.message,
                       'invalid bytes32 value (arg="digest", coderType="bytes32", value="some non hex string")'
         );
+        return
       }
+      expect.fail("should have failed with an error")
     });
 
     it("Should return 0 for non revoked digest", async () => {
@@ -64,8 +69,11 @@ contract('RevocationRegistry', function(accounts) {
         await registryInstance.revoke( digest, { from: accounts[0] })
       } catch (e) {
         assert.equal( e.message, 'Returned error: VM Exception while processing transaction: revert' );
+        return
       }
+      expect.fail("second transaction went through when it should have been rejected")
     });
+
   })
 
 });


### PR DESCRIPTION
## What's here
This PR brings some fixes to the contract:
* credentials can only be marked for revocation once
  This prevents overwriting a previous mark.
* `revocations` mapping is private (can be accessed only through `revoked` method, or by crawling state changes)
* return type is no longer `boolean`; it is the block number. This means one can also check to see when a piece of data was marked, by getting the block timestamp. This means there will be a slight change in the typescript wrapper to use this feature soon.

## Docs
[the Readme](https://github.com/uport-project/revocation-registry/blob/bd063f40d501bed4906d55909cc2ded1f789b3e4/README.md) explains in broad terms how this is supposed to be used and welcomes contributions.

## Testing
I also wrote some tests for the above, since this repo had none of that before.